### PR TITLE
Rename _schema to schema_, remove smart_union, use model_rebuild()

### DIFF
--- a/jsf/schema_types/base.py
+++ b/jsf/schema_types/base.py
@@ -39,9 +39,7 @@ class BaseSchema(BaseModel):
 
     def generate(self, context: Dict[str, Any]) -> Any:
         if self.set_state is not None:
-            context["state"][self.path] = {
-                k: eval(v, context)() for k, v in self.set_state.items()
-            }
+            context["state"][self.path] = {k: eval(v, context)() for k, v in self.set_state.items()}
 
         if self.is_nullable and random.uniform(0, 1) < 0.9:
             return None
@@ -64,7 +62,4 @@ class BaseSchema(BaseModel):
                 Optional[_type],
                 Field(..., description=self.description, example=example),
             )
-        return (
-            _type,
-            Field(..., description=self.description, example=example),
-        )
+        return (_type,Field(..., description=self.description, example=example))

--- a/jsf/schema_types/base.py
+++ b/jsf/schema_types/base.py
@@ -38,6 +38,7 @@ class BaseSchema(BaseModel):
         raise NotImplementedError  # pragma: no cover
 
     def generate(self, context: Dict[str, Any]) -> Any:
+
         if self.set_state is not None:
             context["state"][self.path] = {k: eval(v, context)() for k, v in self.set_state.items()}
 
@@ -62,4 +63,4 @@ class BaseSchema(BaseModel):
                 Optional[_type],
                 Field(..., description=self.description, example=example),
             )
-        return (_type,Field(..., description=self.description, example=example))
+        return (_type, Field(..., description=self.description, example=example))

--- a/jsf/schema_types/base.py
+++ b/jsf/schema_types/base.py
@@ -23,7 +23,7 @@ class BaseSchema(BaseModel):
     # The examples keyword is a place to provide an array of examples that validate against the schema. This isn’t used for validation, but may help with explaining the effect and purpose of the schema to a reader. Each entry should validate against the schema in which is resides, but that isn’t strictly required. There is no need to duplicate the default value in the examples array, since default will be treated as another example.
     examples: Optional[List[Any]] = None
     # The $schema keyword is used to declare that a JSON fragment is actually a piece of JSON Schema. It also declares which version of the JSON Schema standard that the schema was written against.
-    _schema: Optional[str] = Field(None, alias="$schema")
+    schema_: Optional[str] = Field(None, alias="$schema")
     # The $comment keyword is strictly intended for adding comments to the JSON schema source. Its value must always be a string. Unlike the annotations title, description and examples, JSON schema implementations aren’t allowed to attach any meaning or behavior to it whatsoever, and may even strip them at any time. Therefore, they are useful for leaving notes to future editors of a JSON schema, (which is quite likely your future self), but should not be used to communicate to users of the schema.
     comments: Optional[str] = Field(None, alias="$comments")
 
@@ -38,9 +38,10 @@ class BaseSchema(BaseModel):
         raise NotImplementedError  # pragma: no cover
 
     def generate(self, context: Dict[str, Any]) -> Any:
-
         if self.set_state is not None:
-            context["state"][self.path] = {k: eval(v, context)() for k, v in self.set_state.items()}
+            context["state"][self.path] = {
+                k: eval(v, context)() for k, v in self.set_state.items()
+            }
 
         if self.is_nullable and random.uniform(0, 1) < 0.9:
             return None
@@ -63,4 +64,7 @@ class BaseSchema(BaseModel):
                 Optional[_type],
                 Field(..., description=self.description, example=example),
             )
-        return (_type, Field(..., description=self.description, example=example))
+        return (
+            _type,
+            Field(..., description=self.description, example=example),
+        )

--- a/jsf/schema_types/enum.py
+++ b/jsf/schema_types/enum.py
@@ -14,9 +14,7 @@ _types = {"string": str, "integer": int, "number": float}
 class JSFEnum(BaseSchema):
     enum: Optional[List[Union[str, int, float, None]]] = []
 
-    def generate(
-        self, context: Dict[str, Any]
-    ) -> Optional[Union[str, int, float]]:
+    def generate(self, context: Dict[str, Any]) -> Optional[Union[str, int, float]]:
         try:
             return super().generate(context)
         except ProviderNotSetException:

--- a/jsf/schema_types/enum.py
+++ b/jsf/schema_types/enum.py
@@ -14,7 +14,9 @@ _types = {"string": str, "integer": int, "number": float}
 class JSFEnum(BaseSchema):
     enum: Optional[List[Union[str, int, float, None]]] = []
 
-    def generate(self, context: Dict[str, Any]) -> Optional[Union[str, int, float]]:
+    def generate(
+        self, context: Dict[str, Any]
+    ) -> Optional[Union[str, int, float]]:
         try:
             return super().generate(context)
         except ProviderNotSetException:
@@ -35,4 +37,4 @@ class JSFEnum(BaseSchema):
 
     # TODO[pydantic]: The following keys were removed: `smart_union`.
     # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
-    model_config = ConfigDict(smart_union=True)
+    model_config = ConfigDict()

--- a/jsf/schema_types/object.py
+++ b/jsf/schema_types/object.py
@@ -59,4 +59,4 @@ class Object(BaseSchema):
         return self.to_pydantic(context, _type)
 
 
-Object.update_forward_refs()
+Object.model_rebuild()


### PR DESCRIPTION
1. Pydantic v2 introduced [private attributes](https://docs.pydantic.dev/latest/usage/models/#private-model-attributes), where any field starting with an underscore is not treated as a field but a private attribute which is not included in the model schema. 

This PR fixes the following error:
```NameError: Fields must not use names with leading underscores; e.g., use 'schema' instead of '_schema'.```

2. `smart_union` removed in pydantic v2 https://docs.pydantic.dev/dev-v2/migration/#changes-to-config
3. Use `model_rebuild()` instead of `update_forward_refs()` https://docs.pydantic.dev/latest/usage/models/#rebuild-model-schema